### PR TITLE
Add goreleaser for semver based releases

### DIFF
--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -2,26 +2,38 @@ name: binary
 
 on:
   push:
-    branches:
-      - main
+    # run only against tags
+    tags:
+      - '*'
+
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
-  release:
-    name: release
+  goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - name: checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
-      - name: go
-        uses: actions/setup-go@v4
+      - run: git fetch --force --tags
+
+      - uses: actions/setup-go@v4
         with:
           go-version: '>=1.21.0'
 
-      - name: build
-        run: ./scripts/build_binary
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Go Mod
+        run: go mod download
 
+      - uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,42 @@
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    main: ./cmd/torpedo
+
+archives:
+  - format: tar.gz
+    # this name template makes the OS and Arch compatible with the results of uname.
+    name_template: >-
+      torpedo-
+      {{- title .Os }}-
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # use zip for windows archives
+    format_overrides:
+    - goos: windows
+      format: zip
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+
+# The lines beneath this are called `modelines`. See `:help modeline`
+# Feel free to remove those if you don't want/use them.
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj

--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
 # torpedo
+
 Connect to databases in private VPCs the easy way - no VPN required
 
-### How it works
+## How it works
+
 On first run, `torpedo` will create an ECS cluster (this does not cost anything). From there, any time you want to connect to a database `torpedo` will generate random SSH keys, spin up a temporary container that has access to your database, and forward a local port through it. Then you can connect to the database on `localhost` as though it were running locally. The container will be destroyed once you're done with your session.
 
-### Usage
+## Usage
+
 Make sure you have a default AWS profile set or manually set one with `AWS_PROFILE=xxx torpedo`
-```
+
+```shell
 $ torpedo
 🚀 torpedo is ready
 
@@ -16,8 +20,9 @@ it's forwarded to main-1.cz73excokyft.us-east-2.rds.amazonaws.com:5432
 press ctrl+c to exit
 ```
 
-*Help*
-```
+### Help
+
+```shell
 NAME:
    torpedo - A tool to access AWS resources behind a VPC
 
@@ -33,6 +38,7 @@ GLOBAL OPTIONS:
    --verbose   (default: false)
    --help, -h  show help
 ```
-### Acknowledgements
 
-This wasn't my idea! There is a much more fleshed out product called `7777` here: https://port7777.com/ by [Matthieu Napoli](https://mnapoli.fr/) and [Marco Aurélio Deleu](https://blog.deleu.dev/). `torpedo` works in a similar way but was rewritten in Go for faster bootup speeds and made open source for community contribution.
+## Acknowledgements
+
+This wasn't my idea! There is a much more fleshed out product called `7777` here: [https://port7777.com/](https://port7777.com/) by [Matthieu Napoli](https://mnapoli.fr/) and [Marco Aurélio Deleu](https://blog.deleu.dev/). `torpedo` works in a similar way but was rewritten in Go for faster bootup speeds and made open source for community contribution.


### PR DESCRIPTION
I had a look at the release page and notice it was using git commit hashes. I use goreleaser and find it really good build tool to have and automates most of the overhead in doing releases.

Goreleaser will also group up pr/issues as part of release notes.

You can test a local build using `goreleaser release --snapshot --clean`. will output builds to `./dist`

To trigger a release you can:

- create a new tag manually from github UI
- do `git tag -a vx.x.x` and then push the tag with `git push origin vx.x.x`