### PR TITLE
fix(client): use connect config port when creating the ssh tunnel

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -43,7 +43,7 @@ func (c *Client) Start(cfg ConnectConfig) error {
 		cfg.Server,
 		ssh.PublicKeys(c.signer),
 		fmt.Sprintf("%s:%s", cfg.DestinationHost, cfg.DestinationPort),
-		"1234",
+		cfg.BindPort,
 	)
 	c.tunnel = tunnel
 


### PR DESCRIPTION
Hi,

thanks for creating and releasing this useful tool.

I tried using it but noticed in didn't work, and when checking the code I saw that the configured bind port wasn't used in the client.
So here's a fix 😁

Regards.