### PR TITLE
fix(bastion): use db instance id instead of db cluster id

### DIFF
--- a/cmd/torpedo/main.go
+++ b/cmd/torpedo/main.go
@@ -90,7 +90,7 @@ func main() {
 						spin.Disable()
 						options := make([]string, len(b.DBS))
 						for i, db := range b.DBS {
-							options[i] = *db.DBClusterIdentifier
+							options[i] = *db.DBInstanceIdentifier
 						}
 						index, _, err := (&promptui.Select{
 							Label:        "select database",
@@ -105,8 +105,8 @@ func main() {
 						spin.Enable()
 					}
 
-					spin.Suffix = " starting proxy to " + color.BlueString(*target.DBClusterIdentifier)
-					slog.Info("starting bastion", "target", *target.DBClusterIdentifier)
+					spin.Suffix = " starting proxy to " + color.BlueString(*target.DBInstanceIdentifier)
+					slog.Info("starting bastion", "target", *target.DBInstanceIdentifier)
 					_, ip, err := b.Start(b.DBS[0], c.PublicKey())
 					if err != nil {
 						return err


### PR DESCRIPTION
Hi,


noticed an issue when trying to tunnel to a rds instance that isn't an aurora cluster.

![image](https://github.com/sst/torpedo/assets/3422399/9cd121ec-ba98-4f6a-99b4-e516d7e1f275)

![image](https://github.com/sst/torpedo/assets/3422399/35b36e5c-f9cd-40aa-9a4b-e66edc8c6bbe)

This is due to the fact that for the "regular" postgresql rds instance, the `DBClusterIdentifier` is `nil`.
Using the `DBInstanceIdentifier` property instead gives the exact same string for the rds cluster but fixes the issue for the regular db instance.


Regards.