### PR TITLE
fix(bastion): use target db instead of first result

### DIFF
--- a/cmd/torpedo/main.go
+++ b/cmd/torpedo/main.go
@@ -107,7 +107,7 @@ func main() {
 
 					spin.Suffix = " starting proxy to " + color.BlueString(*target.DBInstanceIdentifier)
 					slog.Info("starting bastion", "target", *target.DBInstanceIdentifier)
-					_, ip, err := b.Start(b.DBS[0], c.PublicKey())
+					_, ip, err := b.Start(target, c.PublicKey())
 					if err != nil {
 						return err
 					}


### PR DESCRIPTION
Hi! o/


Didn't notice while testing my previous commit trying to fix bastion initialization since both my RDS instances were in the same VPC.

This commit fixes the call to start bastion using the selected target database.

![image](https://github.com/sst/torpedo/assets/3422399/79fa057e-d5ac-4ccd-8f2e-142243d3ee25)


Regards,
Mehdi.